### PR TITLE
Update zzMaw-Spells.lua

### DIFF
--- a/Scripts/General/zzMaw-Spells.lua
+++ b/Scripts/General/zzMaw-Spells.lua
@@ -487,7 +487,7 @@ function events.PlayerCastSpell(t)
 	
 	local applyHoP = function(s, m)
 		--calculate some common values
-		local buffedPower = 5 + (m + 1) * s --Bless and Stoneskin 4x/5x power value
+		local sharedPower = s + 5 --Bless/Haste/Stoneskin power value
 		local commonTime = Game.Time + const.Hour
 		if m == 3 then commonTime = commonTime + s * const.Hour end --Expiration for M Bless/Shield/Stoneskin
 		if m > 3 then commonTime = commonTime + 5 * s * const.Hour end --Expiration for GM Bless/Shield/Stoneskin
@@ -496,25 +496,22 @@ function events.PlayerCastSpell(t)
 		local buffId = const.PlayerBuff.Bless
 		
 		for i=0,Party.High do
-			if Party[i].SpellBuffs[buffId].Power <= buffedPower then
-				Party[i].SpellBuffs[buffId].Power = buffedPower
+			if Party[i].SpellBuffs[buffId].Power <= sharedPower then
+				Party[i].SpellBuffs[buffId].Power = sharedPower
 				Party[i].SpellBuffs[buffId].Skill = m
 				Party[i].SpellBuffs[buffId].ExpireTime = commonTime
 			end
 		end
 		
 		for _, buffId in ipairs(hopList) do
-			local power = 0
+			local power = sharedPower
 			local expireTime = commonTime
 			
 			if buffId == const.PartyBuff.Haste then
-				power = s + 5
 				expireTime = Game.Time + const.Hour + (m + 1) * m * Const.Minute * s
 			elseif buffId == const.PartyBuff.Heroism then
-				power = 10 + (s * m + s) * m / 2
+				power = 10 + s * m / 2
 				expireTime = Game.Time + (2 + s * (m + 1)) * const.Hour
-			elseif buffId == const.PartyBuff.Stoneskin then
-				power = buffedPower
 			end
 			
 			if Party.SpellBuffs[buffId].Power <= power then

--- a/Scripts/General/zzMaw-Spells.lua
+++ b/Scripts/General/zzMaw-Spells.lua
@@ -160,12 +160,10 @@ function events.PlayerCastSpell(t)
 			local s,m = SplitSkill(t.Player:GetSkill(const.Skills.Spirit))
 			local power = 10 + s * m/2
 			local duration = Game.Time + (2 + s) * const.Hour
-			for i=0,Party.High do
-				if Party.SpellBuffs[9].Power <= power then
-					Party.SpellBuffs[9].Power = power
-					Party.SpellBuffs[9].Skill = m
-					Party.SpellBuffs[9].ExpireTime= duration
-				end
+			if Party.SpellBuffs[9].Power <= power then
+				Party.SpellBuffs[9].Power = power
+				Party.SpellBuffs[9].Skill = m
+				Party.SpellBuffs[9].ExpireTime= duration
 			end
 			if t.MultiplayerData then
 				t.MultiplayerData[1]=power
@@ -173,12 +171,10 @@ function events.PlayerCastSpell(t)
 				t.MultiplayerData[3]=duration
 			end
 		elseif t.RemoteData then
-			for i=0,Party.High do
-				if Party.SpellBuffs[9].Power<=	t.RemoteData[1] then
-					Party.SpellBuffs[9].Power = t.RemoteData[1]
-					Party.SpellBuffs[9].Skill = t.RemoteData[2]
-					Party.SpellBuffs[9].ExpireTime = t.RemoteData[3]
-				end
+			if Party.SpellBuffs[9].Power<=	t.RemoteData[1] then
+				Party.SpellBuffs[9].Power = t.RemoteData[1]
+				Party.SpellBuffs[9].Skill = t.RemoteData[2]
+				Party.SpellBuffs[9].ExpireTime = t.RemoteData[3]
 			end
 		end
 	end


### PR DESCRIPTION
-Fixed Heroism to actually use MAW values
-Fixed Hour of Power and Pain Reflection durations at high skill levels
-Actually implemented Hour of Power scaling per description

This updated Hour of Power scaling introduces some rather significant buffs to the Bless, Stoneskin, and Heroism aspects of Hour of Power.  The bonuses of each are now receiving the 4x/5x skill level (only the durations are multiplied in vanilla, and even then incorrectly) so that means really big boosts to attack, damage, and AC.  It's easy enough to undo this portion of the change and stick with a strictly duration corrected version if you prefer.