### PR TITLE
Increased skill cap

### DIFF
--- a/Scripts/General/ExtraEvents.lua
+++ b/Scripts/General/ExtraEvents.lua
@@ -1,0 +1,897 @@
+local u1, u2, u4, mstr, mcopy, mptr = mem.u1, mem.u2, mem.u4, mem.string, mem.copy, mem.topointer
+local NewCode
+
+local function CastBool(v)
+	return tonumber(v) or (v and 1 or 0)
+end
+
+local function GetPlayer(p)
+	local i = (p - Party.PlayersArray["?ptr"]) / Party.PlayersArray[0]["?size"]
+	return Party.PlayersArray[i], i
+end
+
+local function GetMonster(p)
+	if p < Map.Monsters["?ptr"] then
+		return
+	end
+	local i = (p - Map.Monsters["?ptr"]) / Map.Monsters[0]["?size"]
+	return Map.Monsters[i], i
+end
+
+local function GetObject(p)
+	if Map.Objects.count == 0 then
+		return
+	end
+
+	if p >= Map.Objects["?ptr"] and p < Map.Objects["?ptr"] + Map.Objects["?size"] then
+		local id = math.floor((p - Map.Objects["?ptr"]) / Map.Objects[0]["?size"])
+		return Map.Objects[id], id
+	end
+end
+
+---------------------------------------
+-- Set outdoor light event
+
+mem.autohook2(0x4886e5, function(d)
+	local t = {Minute = Game.Minute, Hour = d.eax}
+	events.call("SetOutdoorLight", t)
+	d.eax = t.Hour
+end)
+
+mem.autohook2(0x4886f4, function(d)
+	local t = {Minute = d.ecx, Hour = Game.Hour}
+	events.call("SetOutdoorLight", t)
+	d.ecx = t.Minute
+end)
+
+mem.autohook2(0x488731, function(d)
+	local t = {Minute = d.ecx, Hour = Game.Hour}
+	events.call("SetOutdoorLight", t)
+	d.ecx = t.Minute
+end)
+
+mem.autohook2(0x488be7, function(d)
+	local t = {Minute = Game.Minute, Hour = d.eax}
+	events.call("SetOutdoorLight", t)
+	d.eax = t.Hour
+end)
+
+mem.autohook2(0x488CAE, function(d)
+	local t = {Minute = d.eax, Hour = Game.Hour}
+	events.call("SetOutdoorLight", t)
+	d.eax = t.Minute
+end)
+
+mem.autohook2(0x488C0E, function(d)
+	local t = {Minute = d.edi, Hour = Game.Hour}
+	events.call("SetOutdoorLight", t)
+	d.edi = t.Minute
+end)
+
+---------------------------------------
+-- Sounds for extra tilesets
+-- allows to change sounds of step or execute event based on tile coordinates;
+-- only outdoors.
+
+local TileSoundData = {}
+mem.autohook2(0x473cf0, function(d) TileSoundData = {Y = d.eax, X = mem.u4[d.esp], Run = mem.u4[d.esp+4]} end)
+mem.autohook2(0x473cf8, function(d)
+	TileSoundData.Sound = d.eax
+	events.call("TileSound", TileSoundData)
+	d.eax = TileSoundData.Sound
+	events.call("TileSoundChosen", TileSoundData)
+end)
+
+---------------------------------------
+-- Step sounds
+-- allows to change sound of step
+-- indoors and outdoors.
+
+mem.autohook(0x4724f4, function(d)
+	if d.edx >= 0 then
+		local t = {Sound = u4[d.esp], Run = u4[d.ebp - 0x34] == 0 and 1 or 0, Facet = Map.Facets[d.edx]}
+		events.call("StepSound", t)
+		u4[d.esp] = t.Sound
+		events.call("StepSoundChosen", t)
+	end
+end)
+mem.autohook(0x473d02, function(d)
+	if d.ecx > 0xffff then
+		local t = {Sound = u4[d.esp], Run = u4[d.esp] == 0x40 and 1 or 0, Facet = structs.ModelFacet:new(d.ecx + d.eax)}
+		events.call("StepSound", t)
+		u4[d.esp] = t.Sound
+		events.call("StepSoundChosen", t)
+	end
+end)
+
+
+---------------------------------------
+-- Got item
+
+mem.autohook2(0x421244, function(d)
+	events.call("GotItem", Mouse.Item.Number)
+end)
+mem.autohook2(0x491a4b, function(d)
+	events.call("GotItem", Mouse.Item.Number)
+end)
+
+
+---------------------------------------
+-- Regen tick event
+-- Standart regen ticks, - unlike timers, continues to tick during party rest.
+
+mem.autohook2(0x491f58, function(d)
+	events.cocall("RegenTick", GetPlayer(d.eax))
+end)
+
+
+---------------------------------------
+-- Party rest events
+
+local function CalcRestFoodCost()
+	local t = {Amount = mem.u1[0x518570]}
+	events.call("CalcRestFoodCost", t)
+	mem.u1[0x518570] = t.Amount
+end
+
+mem.autohook2(0x41ebff, CalcRestFoodCost)
+mem.autohook2(0x41ec24, CalcRestFoodCost)
+mem.autohook2(0x41ec2b, CalcRestFoodCost)
+mem.autohook2(0x41ec36, CalcRestFoodCost)
+
+---------------------------------------
+-- Calc jump height event
+
+mem.autohook2(0x473164, function(d)
+	local t = {Height = d.eax}
+	events.call("CalcJumpHeight", t)
+	d.eax = t.Height
+end)
+
+function events.CalcJumpHeight(t)
+	t.Height = math.min(t.Height, 420)
+end
+
+---------------------------------------
+-- Can cast town portal
+NewCode = mem.asmproc([[
+nop
+nop
+nop
+nop
+nop
+jnz absolute 0x42735b
+idiv ecx
+cmp edx, dword [ss:ebp-4]
+jmp absolute 0x4296a3]])
+mem.asmpatch(0x42969e, "jmp absolute " .. NewCode)
+
+mem.hook(NewCode, function(d)
+	local t = {CanCast = true, Handled = false, Mastery = mem.u4[d.ebp-0xC]}
+	events.call("CanCastTownPortal", t)
+	d.ZF = t.CanCast
+	if t.Handled then
+		d.ecx = 1
+	end
+end)
+
+---------------------------------------
+-- Open chest
+-- Supposed to be used to tweak list of items.
+
+mem.autohook(0x4451c1, function(d)
+	local t = {CanOpen = true, ChestId = d.ecx}
+	events.call("CanOpenChest", t)
+
+	if t.CanOpen then
+		-- event kept for backward compatibility
+		events.call("OpenChest", d.ecx)
+	else
+		d:push(0x445666)
+		return true
+	end
+end)
+
+
+---------------------------------------
+-- Trigger chest trap
+-- Can be used to disable trap / implement special trap logic
+
+mem.autohook(0x41f9bf, function(d)
+	local t = {
+		Handled = false,
+		CanOpenChest = true,
+		ChestId = mem.u4[d.ebp - 0x24],
+		TrapRef = mem.u4[0x5cc030]}
+
+	events.Call("BeforeChestTrapTriggered", t)
+	if t.Handled then
+		d:push(t.CanOpenChest and 0x41fd35 or 0x41fdad)
+		return true
+	end
+	events.Call("ChestTrapTriggered", t.ChestId, t.TrapRef)
+end)
+
+---------------------------------------
+-- Get gold
+-- Triggers when party finds gold (monster's corpses or gold items)
+
+mem.autohook(0x42013a, function(d)
+	local t = {Amount = d.esi}
+	events.call("BeforeGotGold", t)
+	d.esi = t.Amount
+end)
+
+---------------------------------------
+-- Pickup object
+--
+
+local function GetSqDist(x,y,z)
+	local px, py, pz  = XYZ(Party)
+	return (px-x)^2 + (py-y)^2 + (pz-z)^2
+end
+
+NewCode = mem.asmpatch(0x4217da, [[
+	jae absolute 0x421347
+	nop
+	nop
+	nop
+	nop
+	nop
+	jmp absolute 0x4217e0;]])
+
+mem.hook(NewCode + 6, function(d) -- mouse click
+	local t = {Handled = false, ObjectId = bit.rshift(bit.And(d.ecx, 0xffff), 3)}
+	events.call("PickObject", t)
+
+	if t.Handled then
+		d:push(0x421347)
+		return true
+	end
+end)
+
+mem.autohook2(0x468514, function(d) -- spacebar
+	-- Prevent looting items too far away from party.
+	local obj = Mouse:GetTarget()
+	if d.edx ~= obj.Index or (obj.Kind == 2 and GetSqDist(XYZ(Map.Objects[obj.Index])) > 250000) then
+		d:push(0x4686a5)
+		return true
+	end
+
+	if obj.Kind == 2 then
+		local t = {Handled = false, ObjectId = d.edx}
+		events.call("PickObject", t)
+
+		if t.Handled then
+			d:push(0x4686a5)
+			return true
+		end
+	end
+end)
+
+mem.autohook(0x42ad74, function(d) -- telekinesis
+	local t = {Handled = false, ObjectId = d.edi}
+	events.call("PickObject", t)
+
+	if t.Handled then
+		d:push(0x42C200)
+		return true
+	end
+end)
+
+---------------------------------------
+-- Click shop topic
+-- Triggers when player clicks topic in shop
+-- (list of topics provided by RemoveHouseRulesLimits.lua in const.ShopTopics)
+
+mem.autohook2(0x4baa76, function(d)
+	local t = {Handled = false, Topic = d.ecx}
+	events.call("ClickShopTopic", t)
+
+	d.ecx = t.Topic -- topic id change is allowed, but most probably will lead to game crash.
+
+	if t.Handled then
+		d.ZF = true
+	end
+end)
+
+---------------------------------------
+-- Calculate fame
+-- Allows to change calculation base or overhaul counting.
+--
+
+NewCode = mem.asmpatch(0x4903a2, [[
+call absolute 0x4026f4
+nop; mem hook here
+nop
+nop
+nop
+nop
+
+je @over
+
+push 0
+push 0xfa
+push ecx
+push eax
+call absolute 0x4dac60
+
+@over:
+jmp absolute 0x4903bf]])
+
+mem.hook(NewCode + 5, function(d)
+	local t = {Handled = false, Result = 0, Base = Party[0].Experience}
+	events.call("GetFameBase", t)
+
+	if t.Handled then
+		d.eax = t.Result
+	else
+		d.ecx = mem.u4[d.eax + 0xa4]
+		d.eax = t.Base
+	end
+	d.ZF = t.Handled
+end)
+
+---------------------------------------
+-- Get loading screen pic
+-- Allows to change loading screen picture.
+--
+local strlen = string.len
+mem.autohook2(0x44031d, function(d)
+	local ptr = u4[d.esp]
+	local t = {Pic = mstr(ptr)}
+	events.call("GetLoadingPic", t)
+
+	mcopy(ptr, t.Pic)
+	u1[ptr + strlen(t.Pic)] = 0
+end)
+
+---------------------------------------
+-- Can show "Heal" topic
+--
+local function CanShowHealTopic(d)
+	local t = {CanShow = d.eax}
+	events.call("CanShowHealTopic", t)
+	d.eax = CastBool(t.CanShow)
+end
+
+mem.autohook2(0x4b5c3b, CanShowHealTopic)
+mem.autohook2(0x4b5cd7, CanShowHealTopic)
+mem.autohook2(0x4bacdd, CanShowHealTopic)
+
+---------------------------------------
+-- Get travel days cost
+--
+function events.GameInitialized2()
+
+	NewCode = mem.asmpatch(0x4b5626, [[
+	nop; mem hook
+	nop
+	nop
+	nop
+	nop
+	cmp eax, 1
+	jge absolute 0x4b562e]])
+
+	mem.hook(NewCode, function(d)
+		local t = {Days = d.eax, House = mem.u4[0x518678]}
+		events.call("GetTravelDaysCost", t)
+
+		d.eax = t.Days
+	end)
+
+	mem.autohook(0x4b51b8, function(d)
+		local t = {Days = d.ecx, House = mem.u4[0x518678]}
+		events.call("GetTravelDaysCost", t)
+
+		d.ecx = t.Days
+	end)
+
+end
+
+---------------------------------------
+-- Calc training time
+--
+mem.autohook2(0x4b036c, function(d)
+	if Game.CurrentScreen == const.Screens.House then
+		local t = {House = GetCurrentHouse(), Time = d.eax}
+		events.Call("CalcTrainingTime", t)
+		d.eax = t.Time
+		d.edx = 0
+	end
+end)
+
+
+---------------------------------------
+-- Can identify item
+--
+
+mem.autohook2(0x41cf1b, function(d)
+	local t = {CanIdentify = d.ZF, Player = Party[math.max(0, Game.CurrentPlayer)]}
+
+	local object, id = GetObject(d.eax)
+	if object then
+		t.ObjectIndex = id
+		t.Object = object
+		t.Item = object.Item
+	else
+		t.Item = structs.Item:new(d.eax)
+	end
+
+	events.call("CanIdentifyItem", t)
+	d.ZF = t.CanIdentify
+end)
+
+---------------------------------------
+-- Can repair item
+--
+NewCode = mem.asmpatch(0x41cfdd, [[
+mov ecx, dword [ss:esp-4];
+nop; mem hook
+nop
+nop
+nop
+nop
+cmp eax, 1
+mov eax, dword [ss:ebp-4];]])
+
+mem.hook(NewCode + 4, function(d)
+	local t = {CanRepair = d.eax == 1, Player = Party[math.max(0, Game.CurrentPlayer)]}
+
+	local object, id = GetObject(d.ecx)
+	if object then
+		t.ObjectIndex = id
+		t.Object = object
+		t.Item = object.Item
+	else
+		t.Item = structs.Item:new(d.ecx)
+	end
+
+	events.call("CanRepairItem", t)
+
+	d.ecx = 0
+	d.eax = CastBool(t.CanRepair)
+end)
+
+---------------------------------------
+-- Artifact generated
+--
+function events.GameInitialized2()
+	local function ArtifactGenerated(d)
+		local t = {ItemId = d.eax}
+		events.call("ArtifactGenerated", t)
+
+		d.eax = t.ItemId
+	end
+
+	mem.autohook2(0x44dd8d, ArtifactGenerated)
+	mem.autohook(0x4541c4, ArtifactGenerated)
+end
+
+---------------------------------------
+-- Arrow projectile
+--
+mem.autohook(0x42636c, function(d)
+	local t = {ObjId = u4[d.ebp-0xac], PlayerIndex = u2[0x51d822]}
+	events.call("ArrowProjectile", t)
+
+	u4[d.ebp-0xac] = t.ObjId
+end)
+
+---------------------------------------
+-- Dragon breath projectile
+--
+mem.autohook(0x4264ef, function(d)
+	local t = {ObjId = u4[d.ebp-0xac], PlayerIndex = u2[0x51d822]}
+	events.call("DragonBreathProjectile", t)
+
+	u4[d.ebp-0xac] = t.ObjId
+end)
+
+---------------------------------------
+-- Get spell skill
+-- Supposed to modify skill level for default attacks of players (for example, dragon breath)
+--
+local function SpellSchoolBySpell(spell_id)
+	return ((spell_id-1) / 11):floor()
+end
+
+function events.GetSkill(t)
+	local Spell = u2[0x51d820]
+	if Spell > 0 and t.Skill == (SpellSchoolBySpell(Spell) + 12) then
+		t.Spell = Spell
+		events.call("GetSpellSkill", t)
+	end
+end
+
+---------------------------------------
+-- BeforeLeaveGame
+-- called before LeaveGame event, at the moment, when player click "Quit" button second time.
+-- Supposed to be used, when player leaving game, but map data still necessary.
+mem.autohook2(0x433b0d, function() events.call("BeforeLeaveGame") end)
+
+---------------------------------------
+-- MonsterDropItem
+-- Additional event call is in MonsterItems.lua
+--
+mem.autohook(0x40934a, function(d)
+	local mon, monid = GetMonster(d.esi)
+	local t = {MonsterIndex = monid, Monster = mon, ItemId = mem.u4[d.eax], Handled = false}
+	events.Call("MonsterDropItem", t)
+	if t.Handled then
+		d:push(0x409358)
+		return true
+	end
+end)
+
+---------------------------------------
+-- Last created object tracking for optimization of single object creation
+-- via Game.SummonObjects
+--
+local LastObjectBuff = mem.StaticAlloc(4)
+mem.asmpatch(0x42e380, [[
+	call absolute 0x42E05C
+	mov dword [ds:]] .. LastObjectBuff .. [[], eax
+]])
+
+function Game.LastCreatedObject()
+	return u4[LastObjectBuff]
+end
+
+---------------------------------------
+-- Turn based mode start / stop
+--
+--
+mem.autohook(0x42e7f5, function(d)
+	events.call("TurnBasedStarted")
+end)
+mem.autohook(0x42e7df, function(d)
+	events.call("TurnBasedStopped")
+end)
+
+---------------------------------------
+-- MonsterCastSpell
+--
+--
+function events.GameInitialized2()
+
+	local TargetBuf = mem.StaticAlloc(Map.Monsters.limit*4)
+	local LastAttackTargetBuf = mem.StaticAlloc(Map.Monsters.limit*4)
+
+	mem.asmpatch(0x404638, [[
+	mov eax, dword [ss:esp+8]
+	cmp eax, dword [ds:0x40123F]
+	jl @end
+
+	push edx
+	push ecx
+
+	mov ecx, 0x3cc
+	sub eax, dword [ds:0x40123F]
+	cdq
+	idiv ecx
+
+	pop ecx
+	pop edx
+
+	mov word [ds:]] .. TargetBuf+2 .. [[+eax*4], 0;
+	mov word [ds:]] .. TargetBuf   .. [[+eax*4], 4; -- target is party (const.ObjectRefKind)
+
+	@end:
+	mov eax, dword [ss:ebp+0xc]
+	cmp eax, edi]])
+
+	mem.asmpatch(0x404650, [[
+	mov eax, dword [ss:esp+8]
+	cmp eax, dword [ds:0x40123F]
+	jl @end
+
+	push edx
+	push ecx
+
+	mov ecx, 0x3cc
+	sub eax, dword [ds:0x40123F]
+	cdq
+	idiv ecx
+
+	pop ecx
+	pop edx
+
+	mov word [ds:]] .. TargetBuf+2 .. [[+eax*4], si;
+	mov word [ds:]] .. TargetBuf   .. [[+eax*4], 3; -- target is monster (const.ObjectRefKind)
+
+	@end:
+	imul esi, esi, 0x3cc]])
+
+	-- attack target selection
+
+	mem.asmpatch(0x403f02, [[
+	mov eax, dword [ss:ebp-0x4]
+	mov word [ds:]] .. LastAttackTargetBuf+2 .. [[+eax*4], 0;
+	mov word [ds:]] .. LastAttackTargetBuf   .. [[+eax*4], 4; -- target is party (const.ObjectRefKind)
+	mov eax, dword [ds:0xb2155c];]])
+
+	mem.asmpatch(0x403f25, [[
+	mov ecx, dword [ss:ebp-0x4]
+	mov word [ds:]] .. LastAttackTargetBuf+2 .. [[+ecx*4], ax;
+	mov word [ds:]] .. LastAttackTargetBuf   .. [[+ecx*4], 3; -- target is monster (const.ObjectRefKind)
+	imul eax, eax, 0x3cc;]])
+
+	-- Fix damaging player upon death of monster being killed by other monsters.
+	NewCode = mem.asmpatch(0x436a59, [[
+	movzx ecx, word [ds:]] .. LastAttackTargetBuf   .. [[+eax*4]
+	cmp ecx, 0x4
+	jne absolute 0x436e01
+	imul eax, eax, 0x3cc]])
+
+	----
+
+	function GetMonsterTarget(i)
+		return u2[TargetBuf+i*4], u2[TargetBuf+i*4+2]
+	end
+
+	function GetLastAttackedMonsterTarget(i)
+		return u2[LastAttackTargetBuf+i*4], u2[LastAttackTargetBuf+i*4+2]
+	end
+
+	local function MonsterCanCastSpellHook(d)
+		local Mon, MonId = GetMonster(d.esi)
+		if Mon then
+			local TargetRef, TargetId = GetMonsterTarget(MonId)
+			local t = {Spell = u4[d.ebp-0x8], Monster = Mon, MonsterIndex = MonId, Target = 0, Distance = u4[d.ebp-0xC], Result = d.eax, TargetRef = TargetRef}
+			if TargetRef == 4 then
+				t.Target = Party
+			elseif TargetRef == 3 then
+				t.Target = Map.Monsters[TargetId]
+			end
+			events.call("MonsterCanCastSpell", t)
+			d.eax = CastBool(t.Result)
+		end
+	end
+
+	NewCode = mem.asmhook(0x42543c, [[
+	cmp dword [ss:ebp-0x8], 0
+	je @end
+	nop
+	nop
+	nop
+	nop
+	nop
+	@end:]])
+	mem.hook(NewCode+6, MonsterCanCastSpellHook)
+
+	NewCode = mem.asmhook(0x42544f, [[
+	cmp dword [ss:ebp-0x8], 0
+	je @end
+	nop
+	nop
+	nop
+	nop
+	nop
+	@end:]])
+	mem.hook(NewCode+6, MonsterCanCastSpellHook)
+
+	mem.autohook(0x404d9f, function(d)
+		local Mon, MonId = GetMonster(d.esi)
+		if Mon then
+			local TargetRef, TargetId = GetMonsterTarget(MonId)
+			local t = {Spell = d.ecx, Monster = Mon, Target = 0, TargetRef = TargetRef, Handled = false}
+
+			if TargetRef == 4 then
+				t.Target = Party
+			elseif TargetRef == 3 then
+				t.Target = Map.Monsters[TargetId]
+			end
+
+			events.call("MonsterCastSpellM", t)
+			if t.Handled then
+				d.ecx = 0xffff
+			else
+				d.ecx = t.Spell
+			end
+		end
+	end)
+
+end
+
+---------------------------------------
+-- Monsters processed
+--
+local MonstersProcessedHook = mem.asmpatch(0x4026ef, [[
+	nop
+	nop
+	nop
+	nop
+	nop
+	pop edi
+	pop esi
+	pop ebx
+	leave
+	retn]])
+
+mem.hook(MonstersProcessedHook, function()
+	events.call("MonstersProcessed")
+end)
+
+---------------------------------------
+-- On Enter Shop
+-- Allow to forbid entrance
+NewCode = mem.asmpatch(0x443205, [[
+mov [eax], ebx
+mov [eax+4], ebx
+mov eax, [ebp-0x14]
+nop
+nop
+nop
+nop
+nop
+test eax, eax
+jnz absolute 0x4431F2
+]])
+
+mem.hook(NewCode + 8, function(d)
+	local t = {HouseId = d.eax, Banned = 0}
+	events.call("OnEnterShop", t)
+	d.eax = t.Banned
+end)
+
+-- IsMonsterOfKind
+mem.hookfunction(0x436542, 2, 0, function(d, def, id, kind)
+	local t = {
+		Id = id,
+		-- :const.MonsterKind
+		Kind = kind,
+		Result = def(id, kind),
+	}
+	events.cocall("IsMonsterOfKind", t)
+	return t.Result
+end)
+
+
+---------------------------------------
+-- Player yell
+--
+--
+mem.autohook2(0x42e78d, function(d)
+	events.call("PlayerYell")
+end)
+
+---------------------------------------
+-- Player cast spell
+--
+--
+local function EnoughSP(spell_id, Player)
+	local spell_school = SpellSchoolBySpell(spell_id)
+	local skill_id = spell_school + 12
+	local pl_skill, pl_mastery = SplitSkill(Player:GetSkill(skill_id))
+
+	if spell_id > Game.Spells.count then
+		return true, 0, pl_skill, pl_mastery
+	end
+
+	local required = Game.Spells[spell_id].SpellPoints[math.max(pl_mastery, 1)]
+	return Player.SP >= required, required, pl_skill, pl_mastery
+end
+
+-- make target ref upon player selection aswell.
+mem.asmpatch(0x430b28, [[
+	dec ecx
+	mov word [ds:eax+4], cx
+	shl ecx, 3
+	add ecx, 4
+	mov word [ds:eax+0xC], cx]])
+
+-- Interrupted by curse
+-- copy of the original algorythm starting from 0x4262f9
+local InterruptedByCurseFlag = mem.StaticAlloc(4)
+local InterruptedByCurseAsm = mem.asmproc([[
+	call absolute 0x4d99f2
+	push 0x64
+	cdq
+	pop ecx
+	idiv ecx
+	xor eax, eax
+	cmp edx, 32
+	jl @end
+	inc eax
+	@end:
+	ret]])
+
+-- replace original code with fetching pregenerated state flag
+mem.asmpatch(0x4262f9, [[
+	mov al, byte [ds:]] .. InterruptedByCurseFlag .. [[];
+	mov byte [ds:]] .. InterruptedByCurseFlag .. [[], 0
+	test al, al
+	je absolute 0x42630d
+	jmp absolute 0x42d475
+]])
+
+mem.autohook(0x42609e, function(d)
+	-- u4[d.ebp-0xC8] - number of current spell slot being processed
+	-- 0x14 - size of spell slot
+	local slot = 0x51d820 + u4[d.ebp-0xC8] * 0x14
+
+	local spell_id = u2[slot]
+	if spell_id >= Game.Spells.limit then
+		return
+	end
+
+	local player_id = u2[slot + 2]
+	local player = Party.PlayersArray[player_id]
+	local target_ref = u2[slot + 0xc]
+	local is_spell_scroll = bit.And(u1[slot + 8], 1) == 1
+	local skill_set = u2[slot + 10] > 0
+	local enough_sp, sp_cost, skill, mastery
+
+	if is_spell_scroll then
+		enough_sp, sp_cost, skill, mastery = true, 0, 7, 3
+	elseif skill_set then
+		skill, mastery = SplitSkill(u2[slot + 10])
+		enough_sp, sp_cost = EnoughSP(spell_id, player)
+	else
+		enough_sp, sp_cost, skill, mastery = EnoughSP(spell_id, player)
+	end
+
+	local cursed = false
+	if spell_id < 100 and player.Conditions[const.Condition.Cursed] > 0 then
+		cursed = mem.call(InterruptedByCurseAsm) == 1
+	end
+	u4[InterruptedByCurseFlag] = cursed and 1 or 0
+
+	local t = {
+		SpellId = spell_id,
+		PlayerIndex = player_id,
+		Player = player,
+		InventorySlot = mem.u2[slot + 6],
+		SPCost = sp_cost,
+		Skill = skill,
+		Mastery = mastery,
+		TargetKind = bit.And(target_ref, 7), -- object or monster
+		TargetId = bit.rshift(target_ref, 3),
+		IsSpellScroll = is_spell_scroll,
+		CurseInterrupt = cursed,
+		Handled = false}
+
+	if Multiplayer and Multiplayer.in_game then
+		events.call("PlayerCastSpellFirst", t) -- used to insert remote data
+		events.call("PlayerCastSpell", t)
+		events.call("PlayerCastSpellLast", t) -- used to fetch userdata for remote players
+	else
+		events.call("PlayerCastSpell", t)
+	end
+
+	if t.TargetKind == 4 then
+		-- clean service player reference to not mess up with original spells handler.
+		u2[slot + 0xc] = 0
+	end
+
+	if t.Handled then
+		mem.u2[slot] = 0
+		d:push(0x42d45d)
+		return true
+	end
+
+	-- if spell skill is not set, value will be taken from caster's data, bypassing GetSkill event in some cases.
+	-- if spell skill is set, caster won't loose spellpoints
+	if skill_set then
+		u2[slot + 10] = JoinSkill(t.Skill, t.Mastery)
+	end
+end)
+
+-- Spells test
+
+--~ local count = 1
+--~ local function test_spells()
+--~ 	if count > 125 then
+--~ 		RemoveTimer()
+--~ 		Game.ShowStatusText("Done")
+--~ 	else
+--~ 		Game.ShowStatusText(tostring(count))
+--~ 		CastSpellDirect(count)
+--~ 	end
+
+--~ 	count = count + 1
+--~ end
+--~ Timer(test_spells, const.Minute / 4)
+
+

--- a/Scripts/General/zzMAW-Skills.lua
+++ b/Scripts/General/zzMAW-Skills.lua
@@ -1,3 +1,26 @@
+local function UncapSkills(char)
+	for _,skill in pairs(const.Skills) do
+		local value = char.Skills[skill]
+		
+		if value > 0x100 then
+			char.Skills[skill] = value - 0x100 + 0x1000
+		elseif value > 0x80 then
+			char.Skills[skill] = value - 0x80 + 0x800
+		elseif value > 0x40 then
+			char.Skills[skill] = value - 0x40 + 0x400
+		end
+	end
+end
+
+function events.LoadMap(wasInGame)
+	if not vars.UncappedSkills then
+		vars.UncappedSkills = 1
+		for i=0,Party.PlayersArray.High do
+			UncapSkills(Party.PlayersArray[i])
+		end
+	end
+end
+
 -- weapon base recovery bonuses
 
 oldWeaponBaseRecoveryBonuses =

--- a/Scripts/General/zzMaw-Spells.lua
+++ b/Scripts/General/zzMaw-Spells.lua
@@ -530,36 +530,7 @@ function events.PlayerCastSpell(t)
 			end
 		elseif t.RemoteData then
 			applyHoP(t.RemoteData[1], t.RemoteData[2])
-		end	
-	end
-	
-	--Pain Reflection
-	if t.SpellId==const.Spells.PainReflection then
-		if not t.RemoteData then
-			t.Skill = 0
-			local s,m = SplitSkill(t.Player:GetSkill(const.Skills.Dark))
-			local power= s + 14
-			local expireMult = m > 3 and 15 or 5
-			for i=0,Party.High do
-				if Party[i].SpellBuffs[10].Power <= power then
-					Party[i].SpellBuffs[10].Power = power
-					Party[i].SpellBuffs[10].Skill = t.Mastery
-					Party[i].SpellBuffs[10].ExpireTime = Game.Time + const.Hour + const.Minute * expireMult * s
-				end
-			end
-			if t.MultiplayerData then
-				t.MultiplayerData[1] = power
-				t.MultiplayerData[2] = Game.Time + const.Hour + const.Minute * expireMult * s
-			end
-		elseif t.RemoteData then
-			for i=0,Party.High do
-				if Party[i].SpellBuffs[10].Power <= t.RemoteData[1] then
-					Party[i].SpellBuffs[10].Power = t.RemoteData[1]
-					Party[i].SpellBuffs[10].Skill = t.Mastery
-					Party[i].SpellBuffs[10].ExpireTime = t.RemoteData[2]
-				end
-			end
-		end	
+		end
 	end
 end
 

--- a/Scripts/Structs/After/RemoveSkillValueLimits.lua
+++ b/Scripts/Structs/After/RemoveSkillValueLimits.lua
@@ -1,0 +1,966 @@
+local LogId = "RemoveSkillValueLimits"
+local Log = Log
+Log(Merge.Log.Info, "Init started: %s", LogId)
+
+-- Create null-terminated string from given lua string
+local function mem_cstring(str)
+	local ptr = mem.StaticAlloc(#str + 1)
+	mem.copy(ptr, str, #str + 1)
+	return ptr
+end
+
+local function get_player_from_ptr(ptr)
+	if ptr < 0xB2187C or ptr > 0xB7AD24 then
+		MF.Log(Merge.Log.Error, "%s: invalid player pointer in GetPlayerFromPtr - 0x%X", LogId, ptr)
+		return nil, -1
+	end
+	local player_id = (ptr - Party.PlayersArray["?ptr"])/Party.PlayersArray[0]["?size"]
+	return Party.PlayersArray[player_id], player_id
+end
+
+-- MaxSkillVal is maximum value of base_skill + skill_bonus
+-- Should be 2^N-1 with maximum value of 0x3FF
+-- MM8 value is 0x3F
+local MaxSkillVal = 0x3FF
+-- MaxSkillBase is maximum value of base_skill
+-- MM8 value is 0x3C
+local MaxSkillBase = 0x1F4
+-- Bit offset of Expert Mastery
+-- Shouldn't be less than log2(MaxSkillVal + 1) [N from above]
+-- MM8 value is 6
+local ExpertBit = 10
+
+-- WARNING: there are a lot of hardcoded values in this file still.
+
+local MF, MO = Merge.Functions, Merge.Offsets
+local floor, max, pow = math.floor, math.max, math.pow
+local asmpatch, asmproc, memcall = mem.asmpatch, mem.asmproc, mem.call
+local strformat = string.format
+
+local MaxSkillValH = floor(MaxSkillVal / 0x100)
+local SkillAnd = 0xFFFFFFFF - MaxSkillVal
+local SkillAndX = 0xFFFF - MaxSkillVal
+local MaxSkillValStr, MaxSkillValHStr = strformat("0x%X", MaxSkillVal), strformat("0x%X", MaxSkillValH)
+local MaxSkillBaseStr = strformat("0x%X", MaxSkillBase)
+local SkillAndStr = strformat("0x%X", SkillAnd)
+local SkillAndXStr = strformat("0x%X", SkillAndX)
+
+local MasterBit, GrandMasterBit = ExpertBit + 1, ExpertBit + 2
+local ExpertBitH = ExpertBit - 8
+local MasterBitH, GrandMasterBitH = ExpertBitH + 1, ExpertBitH + 2
+
+local ExpertBitV = pow(2, ExpertBit)
+local ExpertBitVH = ExpertBit > 7 and pow(2, ExpertBitH) or 0
+local MasterBitV = ExpertBitV * 2
+local MasterBitVH = MasterBit > 7 and pow(2, MasterBitH) or 0
+local GrandMasterBitV, GrandMasterBitVH = ExpertBitV * 4, pow(2, GrandMasterBitH)
+local ExpertBitStr = strformat("0x%X", ExpertBit)
+local MasterBitStr = strformat("0x%X", MasterBit)
+local GrandMasterBitStr = strformat("0x%X", GrandMasterBit)
+local ExpertBitVStr, ExpertBitVHStr = strformat("0x%X", ExpertBitV), strformat("0x%X", ExpertBitVH)
+local MasterBitVStr, MasterBitVHStr = strformat("0x%X", MasterBitV), strformat("0x%X", MasterBitVH)
+local GrandMasterBitVStr = strformat("0x%X", GrandMasterBitV)
+local GrandMasterBitVHStr = strformat("0x%X", GrandMasterBitVH)
+
+function SplitSkill(val)
+	if not val then return end
+	local n = val % (MaxSkillVal + 1)
+	local mast = 0
+	if val >= GrandMasterBitV then
+		mast = 4
+	elseif val >= MasterBitV then
+		mast = 3
+	elseif val >= ExpertBitV then
+		mast = 2
+	elseif val >= 1 then
+		mast = 1
+	end
+	return n, mast
+end
+
+local ConvertMastery = {[0] = 0, [1] = 0, [2] = ExpertBitV, [3] = MasterBitV, [4] = GrandMasterBitV}
+
+JoinSkill = function(skill, mastery)
+	if skill > MaxSkillVal then
+		Log(Merge.Log.Error, "Incorrect skill value %d at JoinSkill()", skill)
+		skill = MaxSkillVal
+	end
+	if mastery > 4 then
+		Log(Merge.Log.Error, "Incorrect mastery %d at JoinSkill()", mastery)
+		mastery = 4
+	end
+	return skill + (ConvertMastery[mastery] or 0)
+end
+
+-- GetSkillMastery
+-- Note: returns 1 if skill value is 0
+asmpatch(0x455B09, [[
+push 4
+pop eax
+test cx, ]] .. GrandMasterBitV .. [[;
+jnz @end
+dec eax
+test cx, ]] .. MasterBitV .. [[;
+jnz @end
+dec eax
+test cx, ]] .. ExpertBitV .. [[;
+jnz @end
+dec eax
+@end:
+]], 0x455B24 - 0x455B09)
+
+-- GetSkillMastery0
+-- Note: returns 0 if skill value is 0
+local get_skill_mastery0 = asmproc([[
+xor eax, eax
+test ecx, ecx
+jz @end
+call absolute 0x455B09
+@end:
+retn
+]])
+MO.GetSkillMastery0 = get_skill_mastery0
+
+-- GetPlayerSkillMastery
+-- ecx - player ptr; edx - skill id
+local get_player_skill_mastery = asmproc([[
+push esi
+mov esi, ecx
+lea ecx, [ecx + edx * 2 + 0x378]
+movzx ecx, word ptr [ecx]
+nop
+nop
+nop
+nop
+nop
+call absolute ]] .. get_skill_mastery0 .. [[;
+pop esi
+retn]])
+MO.GetPlayerSkillMastery = get_player_skill_mastery
+
+mem.hook(get_player_skill_mastery + 13, function(d)
+	local t = {PlayerPtr = d.esi, Skill = d.edx, Result = d.ecx}
+	t.Player, t.PlayerIndex = get_player_from_ptr(d.esi)
+	events.call("GetPlayerSkillMastery", t)
+	d.ecx = t.Result
+end)
+
+MF.GetPlayerSkillMastery = function(player, skill)
+	return memcall(get_player_skill_mastery, 2, player["?ptr"], skill)
+end
+
+-- Remove general bonus limit
+
+-- GetSkill
+mem.asmpatch(0x48F060, [[
+and ecx, ]] .. MaxSkillValStr .. [[;
+add ecx, ebx
+cmp ecx, ]] .. MaxSkillValStr)
+mem.nop(0x48F065, 3)
+mem.asmpatch(0x48F06A, [[
+and eax, ]] .. SkillAndStr .. [[;
+add eax, ]].. MaxSkillValStr)
+mem.nop(0x48F06F, 1)
+mem.asmpatch(0x48F076, [[
+and eax, ]] .. SkillAndStr .. [[;
+inc eax
+jmp absolute 0x48F07E]])
+mem.nop(0x48F07B, 1)
+
+-- Skill upgrade (0x4B074B)
+asmpatch(0x4B0AA5, [[
+lea ecx, [eax+ecx*2+0x378]
+and word ptr [ecx], ]] .. MaxSkillVal, 11)
+asmpatch(0x4B0ACE, [[
+lea ecx, [eax+ecx*2+0x378]
+or word ptr [ecx], ]] .. GrandMasterBitV, 10)
+asmpatch(0x4B0B15, [[
+lea ecx, [eax+ecx*2+0x378]
+or word ptr [ecx], ]] .. MasterBitV, 10)
+asmpatch(0x4B0B52, [[
+lea ecx, [eax+ecx*2+0x378]
+or word ptr [ecx], ]] .. ExpertBitV, 10)
+
+-- Character Skills panel
+mem.asmpatch(0x418D8A, [[
+mov [ebp-24h], edx
+and dword ptr [ebp-24h], ]] .. MaxSkillValStr)
+
+mem.asmpatch(0x418DF8, "test byte ptr [ebp-0xF], " .. GrandMasterBitVH)
+mem.asmpatch(0x418E22, "test byte ptr [ebp-0xF], " .. MasterBitVH)
+mem.asmpatch(0x418E30, "test byte ptr [ebp-0xF], " .. ExpertBitVH)
+
+local plus_one = mem_cstring(" (+1)")
+
+asmpatch(0x418E5A, [[
+mov ecx, [ebp - 0x48]
+mov edx, [ebp - 0x20]
+call absolute ]] .. get_player_skill_mastery .. [[;
+push eax
+mov ecx, [ebp - 0x10]
+call absolute 0x455B09
+pop edx
+cmp eax, edx
+jge @std
+push ]] .. plus_one .. [[;
+push 0x5DF0E0
+call absolute 0x4D9E30
+add esp, 0x8
+@std:
+push 0xEC]])
+
+mem.asmpatch(0x41912D, [[
+mov [ebp-24h], edx
+and dword ptr [ebp-24h], ]] .. MaxSkillValStr)
+
+mem.asmpatch(0x4191A5, "test byte ptr [ebp-0xF], " .. GrandMasterBitVH)
+mem.asmpatch(0x4191CF, "test byte ptr [ebp-0xF], " .. MasterBitVH)
+mem.asmpatch(0x4191DD, "test byte ptr [ebp-0xF], " .. ExpertBitVH)
+
+asmpatch(0x419207, [[
+mov ecx, [ebp - 0x48]
+mov edx, [ebp - 0x20]
+call absolute ]] .. get_player_skill_mastery .. [[;
+push eax
+mov ecx, [ebp - 0x10]
+call absolute 0x455B09
+pop edx
+cmp eax, edx
+jge @std
+push ]] .. plus_one .. [[;
+push 0x5DF0E0
+call absolute 0x4D9E30
+add esp, 0x8
+@std:
+push 0xEC]])
+
+mem.asmpatch(0x4194D7, [[
+mov [ebp-24h], edx
+and dword ptr [ebp-24h], ]] .. MaxSkillValStr)
+
+mem.asmpatch(0x419545, "test byte ptr [ebp-0xF], " .. GrandMasterBitVH)
+mem.asmpatch(0x41956F, "test byte ptr [ebp-0xF], " .. ExpertBitVH)
+mem.asmpatch(0x41957D, "test byte ptr [ebp-0xF], " .. MasterBitVH)
+
+asmpatch(0x4195A7, [[
+mov ecx, [ebp - 0x48]
+mov edx, [ebp - 0x20]
+call absolute ]] .. get_player_skill_mastery .. [[;
+push eax
+mov ecx, [ebp - 0x10]
+call absolute 0x455B09
+pop edx
+cmp eax, edx
+jge @std
+push ]] .. plus_one .. [[;
+push 0x5DF0E0
+call absolute 0x4D9E30
+add esp, 0x8
+@std:
+push 0xEC]])
+
+mem.asmpatch(0x41987A, [[
+mov [ebp-24h], edx
+and dword ptr [ebp-24h], ]] .. MaxSkillValStr)
+
+mem.asmpatch(0x4198E8, "test byte ptr [ebp-0xF], " .. GrandMasterBitVH)
+mem.asmpatch(0x419912, "test byte ptr [ebp-0xF], " .. ExpertBitVH)
+mem.asmpatch(0x419920, "test byte ptr [ebp-0xF], " .. MasterBitVH)
+
+asmpatch(0x41994A, [[
+mov ecx, [ebp - 0x48]
+mov edx, [ebp - 0x20]
+call absolute ]] .. get_player_skill_mastery .. [[;
+push eax
+mov ecx, [ebp - 0x10]
+call absolute 0x455B09
+pop edx
+cmp eax, edx
+jge @std
+push ]] .. plus_one .. [[;
+push 0x5DF0E0
+call absolute 0x4D9E30
+add esp, 0x8
+@std:
+push 0xEC]])
+
+mem.asmpatch(0x419E59, [[
+test word ptr [edx+ecx*2+0x378], ]] .. MaxSkillValStr)
+mem.asmpatch(0x419F25, [[
+test word ptr [edx+ecx*2+0x378], ]] .. MaxSkillValStr)
+
+-- Increase skill
+-- Required skillpoints
+mem.asmpatch(0x43234B, [[
+mov edx, eax
+and edx, ]] .. MaxSkillValStr)
+-- Increase skill
+mem.asmpatch(0x432359, [[
+mov dx, ax
+and dx, ]] .. MaxSkillValStr .. [[;
+cmp dx, ]] .. MaxSkillBaseStr)
+mem.nop(0x43235E, 3)
+mem.asmpatch(0x432374, [[
+and eax, ]] .. MaxSkillValStr .. [[;
+sub [ecx+0x1BF4], eax
+]])
+--
+mem.asmpatch(0x4C9E71, [[
+jnz absolute 0x4C9EDE
+and eax, ]] .. MaxSkillValStr)
+mem.asmpatch(0x4C9EB9, [[
+and eax, ]] .. MaxSkillValStr .. [[;
+push eax
+push 0x4F2F78
+]])
+mem.asmpatch(0x4C9EDE, [[
+and eax, ]] .. MaxSkillValStr .. [[;
+inc eax
+cmp [edi+0x1BF4], eax
+]])
+
+-------------------
+-- MonsterCastSpell
+asmpatch(0x404D91, [[
+and ebx, ]] .. MaxSkillValStr .. [[;
+mov dword ptr [ebp - 4], ebx]])
+--   Poison Spray shots
+asmpatch(0x404E60, [[
+mov ecx, eax
+shl ecx, 1
+dec ecx
+jmp absolute 0x404E7F
+]], 10)
+--   Sparks count
+asmpatch(0x4050A9, [[
+mov ecx, eax
+shl ecx, 1
+inc ecx
+jmp absolute 0x4050C9
+]], 10)
+--   Shrapmetal fragments
+asmpatch(0x405203, [[
+mov ecx, eax
+shl ecx, 1
+inc ecx
+jmp absolute 0x405219
+]], 10)
+--   Meteor Shower meteors count
+asmpatch(0x40563A, [[
+mov dword ptr [ebp-0x9C], ecx
+mov ecx, dword ptr [0xB21558]
+mov dword ptr [ebp-0x84], eax
+mov dword ptr [ebp-0x8C], ecx
+mov ecx, dword ptr [ebp+0x10]
+call absolute 0x455B09
+inc eax
+shl eax, 2
+jmp absolute 0x405672
+]])
+
+------------
+
+-- Alchemy
+mem.asmpatch(0x4157B4, [[
+mov edi, eax
+and edi, ]] .. MaxSkillValStr)
+
+-- Notifications
+mem.asmpatch(0x417295, [[
+mov cx, word [ds:ebx*2+esi+0x378]
+and eax, ]] .. MaxSkillValStr .. [[;
+push 0x4F3BB8
+and ecx, ]] .. MaxSkillValStr)
+mem.nop2(0x41729A, 0x4172A7)
+
+mem.asmpatch(0x41741e, [[
+mov cx, word [ds:edi]
+and eax, ]] .. MaxSkillValStr .. [[;
+and ecx, ]] .. MaxSkillValStr)
+mem.nop2(0x417423, 0x417426)
+
+mem.asmpatch(0x417463, [[
+mov cx, word [ds:edi]
+and eax, ]] .. MaxSkillValStr .. [[;
+and ecx, ]] .. MaxSkillValStr)
+mem.nop2(0x417468, 0x41746B)
+
+-- Id Monster
+mem.asmpatch(0x41E07C, [[
+mov edi, ecx
+and edi, ]] .. MaxSkillValStr)
+
+--
+mem.asmpatch(0x4203C1, [[
+and ecx, ]] .. MaxSkillValStr .. [[;
+inc ecx
+cmp eax, ecx
+]])
+
+-- Spell target type selection
+--   Expert (Skill)
+asmpatch(0x425C11, [[
+call absolute 0x455B09
+cmp eax, 2
+jmp short 0x425C59 - 0x425C11
+]], 0xA)
+--   Expert (Player)
+MO.SkillMasteryTarget2 = asmproc([[
+pop edx
+mov ecx, eax
+call absolute ]] .. get_player_skill_mastery .. [[;
+jmp absolute 0x425C16]])
+--   Master (Player)
+MO.SkillMasteryTarget3 = asmproc([[
+pop edx
+mov ecx, eax
+call absolute ]] .. get_player_skill_mastery .. [[;
+jmp absolute 0x425C2E]])
+--   GM (Player)
+MO.SkillMasteryTarget4 = asmproc([[
+pop edx
+mov ecx, eax
+call absolute ]] .. get_player_skill_mastery .. [[;
+jmp absolute 0x425C56]])
+--   Bless target type
+asmpatch(0x425C00, [[
+mov ecx, dword ptr [ebp + 8]
+test ecx, ecx
+jnz short 0x425C11 - 0x425C00
+push 16
+jmp absolute ]] .. MO.SkillMasteryTarget2,
+0x11)
+--   Preservation target type
+asmpatch(0x425C22, [[
+push 16
+jmp absolute ]] .. MO.SkillMasteryTarget3)
+--   Pain Reflection target type
+asmpatch(0x425C3A, [[
+push 20
+jmp absolute ]] .. MO.SkillMasteryTarget3)
+--   Hammerhands target type
+asmpatch(0x425C4A, [[
+push 18
+jmp absolute ]] .. MO.SkillMasteryTarget4)
+
+-- Magic
+mem.asmpatch(0x426221, [[
+and edi, ]] .. MaxSkillValStr ..[[;
+mov dword ptr [ebp - 0x3C], edi
+jmp absolute 0x426242]])
+mem.asmpatch(0x42623A, [[
+mov edi, eax
+and edi, ]] .. MaxSkillValStr)
+-- Maybe use GetSkillMastery call instead of following patches
+mem.asmpatch(0x426242, "test ah, 0x10")
+mem.asmpatch(0x426250, [[
+test ah, 8
+jz absolute 0x42625D
+mov dword ptr [ebp-0xC], 3
+]])
+mem.nop2(0x426255, 0x42625B)
+mem.asmpatch(0x42625D, [[
+test ah, 4
+push 0
+pop eax
+]])
+
+-- Quick Spell SP cost
+mem.asmpatch(0x42E86B, [[
+test ah, 0x10
+jz absolute 0x42E87D
+]])
+mem.asmpatch(0x42E87D, [[
+test ah, 0x8
+jz absolute 0x42E88E
+lea eax, [ecx+ecx*4]
+]])
+mem.asmpatch(0x42E88E, [[
+test ah, 0x4
+lea eax, [ecx+ecx*4]
+]])
+
+-- Spell scroll skill value
+-- Set during SpellScrollSkillValue event in ExtraEvents.lua
+--mem.asmpatch(0x4320D1, 'push ' .. JoinSkill(5, 3))
+
+-- damageMonsterFromParty
+--
+mem.asmpatch(0x436FFB, [[
+mov ax, [ebx]
+and eax, ]] .. MaxSkillValStr)
+--   MainHand Weapon
+--   Mace Stun
+mem.asmpatch(0x4371BE, [[
+mov ebx, eax
+and ebx, ]] .. MaxSkillValStr)
+
+--   Mace Paralyze
+mem.asmpatch(0x4371E9, [[
+mov ebx, eax
+and ebx, ]] .. MaxSkillValStr)
+
+--   Staff Stun
+mem.asmpatch(0x437215, [[
+mov ebx, eax
+and ebx, ]] .. MaxSkillValStr)
+
+--   Mace Paralyze
+mem.asmpatch(0x4377B8, [[
+and ebx, ]] .. MaxSkillValStr .. [[;
+imul ebx, 1E00h
+]])
+mem.nop(0x4377BD, 4)
+
+-- Unarmed Evasion
+mem.asmpatch(0x4380C4, [[
+and edi, ]] .. MaxSkillValStr .. [[;
+cmp edx, edi
+]])
+
+--
+mem.asmpatch(0x439162, [[
+and edx, ]] .. MaxSkillValStr .. [[;
+mov ecx, esi
+]])
+
+-- evt.Cmd
+-- evt.CheckSkill
+mem.asmpatch(0x443C1B, [[
+mov ebp, eax
+shr ebp, ]] .. ExpertBitStr)
+mem.asmpatch(0x443C26, [[
+shr ebp, ]] .. MasterBitStr)
+mem.asmpatch(0x443C32, [[
+shr ebp, ]] .. GrandMasterBitStr .. [[;
+and eax, ]] .. MaxSkillValStr)
+mem.nop(0x443C38, 3)
+mem.asmpatch(0x443CD6, [[
+mov ecx, eax
+shr ecx, ]] .. ExpertBitStr)
+mem.asmpatch(0x443CE1, [[
+shr ecx, ]] .. MasterBitStr)
+mem.asmpatch(0x443CED, [[
+shr ecx, ]] .. GrandMasterBitStr .. [[;
+and eax, ]] .. MaxSkillValStr)
+mem.nop(0x443CF3, 3)
+
+-- evt.Cmp
+mem.asmpatch(0x4476B8, [[
+cmp ebx, ]] .. MaxSkillValStr .. [[;
+movzx edi, word ptr [esi+eax*2+0x2F0]
+]])
+mem.asmpatch(0x4476CC, [[
+and edi, ]] .. MaxSkillValStr .. [[;
+jmp absolute 0x447AC8
+]])
+
+-- evt.Set
+mem.asmpatch(0x4481B1, [[
+cmp word ptr [ebp+0xC], ]] .. MaxSkillValStr .. [[;
+jle absolute 0x4481D1
+lea ecx, [edi+eax*2+0x2F0]
+mov ax, [ecx]
+and ax, ]] .. SkillAndXStr .. [[;
+or ax, [ebp+0xC]
+]])
+mem.nop2(0x4481B7, 0x4481C9)
+mem.asmpatch(0x4481D1, [[
+mov dx, [ebp+0xC]
+lea eax, [edi+eax*2+0x2F0]
+xor ecx, ecx
+mov cx, [eax]
+and ecx, ]] .. MaxSkillValStr)
+mem.nop2(0x4481D6, 0x4481E4)
+
+-- evt.Add
+mem.asmpatch(0x448AE2, [[
+cmp word ptr [ebp+0xC], ]] .. MaxSkillValStr .. [[;
+jle absolute 0x448B12
+]])
+mem.asmpatch(0x448AF8, [[
+and eax, ]] .. MaxSkillValStr .. [[;
+add eax, edx
+cmp eax, ]] .. MaxSkillBaseStr .. [[;
+jle absolute 0x448B05
+push ]] .. MaxSkillBaseStr)
+mem.nop2(0x448AFD, 0x448B04)
+mem.asmpatch(0x448B05, [[
+and ecx, ]] .. SkillAndStr .. [[;
+or ecx, eax
+]])
+mem.asmpatch(0x448B12, [[
+mov dx, [ebp+0xC]
+]])
+mem.asmpatch(0x448B1E, [[
+mov cx, [eax]
+and ecx, ]] .. MaxSkillValStr)
+
+-- Monsters.txt
+-- SpellSkill
+mem.asmpatch(0x453598, [[
+mov edi, [ebp+edi-0x1E0]
+and eax, ]] .. MaxSkillValStr)
+mem.nop(0x45359F, 3)
+mem.asmpatch(0x4535B7, [[
+jnz absolute 0x4535C2
+or word ptr [esi+0x42], ]] .. ExpertBitVStr)
+mem.asmpatch(0x4535D1, [[
+jnz absolute 0x4535DC
+or word ptr [esi+0x42], ]] .. MasterBitVStr)
+local gm = "GM"
+mem.asmpatch(0x4535EB, [[
+jz short @gm
+push ]] .. mem.topointer(gm) .. [[;
+push edi
+call absolute 0x4DA920
+test eax, eax
+pop ecx
+pop ecx
+jnz absolute 0x453BAD
+@gm:
+or word ptr [esi+0x42], ]] .. GrandMasterBitVStr)
+mem.nop(0x4535F1, 4)
+-- Spell2Skill
+mem.asmpatch(0x4536B2, [[
+mov edi, [ebp+edi-0x25C]
+and eax, ]] .. MaxSkillValStr)
+mem.nop(0x4536B9, 3)
+mem.asmpatch(0x4536D1, [[
+jnz absolute 0x4536DC
+or word ptr [esi+0x44], ]] .. ExpertBitVStr)
+mem.asmpatch(0x4536EB, [[
+jnz absolute 0x4536F6
+or word ptr [esi+0x44], ]] .. MasterBitVStr)
+mem.asmpatch(0x453705, [[
+jz short @gm
+push ]] .. mem.topointer(gm) .. [[;
+push edi
+call absolute 0x4DA920
+test eax, eax
+pop ecx
+pop ecx
+jnz absolute 0x453BAD
+@gm:
+or word ptr [esi+0x44], ]] .. GrandMasterBitVStr)
+mem.nop(0x45370B, 4)
+
+-- Spell scroll skill value (Fire Aura etc.)
+mem.asmpatch(0x466B88, 'push ' .. JoinSkill(5, 3))
+
+-- Bow GM damage bonus
+local BowDamageIncludeItemsBonus = Merge and Merge.Settings and Merge.Settings.Skills
+		and Merge.Settings.Skills.BowDamageIncludeItemsBonus or 0
+
+if BowDamageIncludeItemsBonus == 1 then
+	-- Take skill bonus from items into account
+	-- GetRangedDamageMin
+	mem.asmpatch(0x48CA86, [[
+	push 5
+	mov ecx, esi
+	call absolute 0x48EF4F
+	and eax, ]] .. MaxSkillValStr)
+	-- GetRangedDamageMax
+	mem.asmpatch(0x48CAEE, [[
+	push 5
+	mov ecx, esi
+	call absolute 0x48EF4F
+	and eax, ]] .. MaxSkillValStr)
+	-- CalcRangedDamage
+	mem.asmpatch(0x48CBEB, [[
+	push 5
+	mov ecx, ebx
+	sub ecx, 0x382
+	call absolute 0x48EF4F
+	and eax, ]] .. MaxSkillValStr .. [[;
+	add esi, eax]], 0x48CBF2 - 0x48CBEB)
+else
+	-- Use base skill value
+	-- GetRangedDamageMin
+	mem.asmpatch(0x48CA86, [[
+	mov ax, [esi+0x382]
+	and eax, ]] .. MaxSkillValStr)
+	-- GetRangedDamageMax
+	mem.asmpatch(0x48CAEE, [[
+	mov ax, [esi+0x382]
+	and eax, ]] .. MaxSkillValStr)
+	-- CalcRangedDamage
+	mem.asmpatch(0x48CBEB, [[
+	mov ax, [ebx]
+	and eax, ]] .. MaxSkillValStr .. [[;
+	add esi, eax]], 0x48CBF2 - 0x48CBEB)
+end
+mem.nop(0x48CA8B, 4)
+mem.nop(0x48CAF3, 4)
+
+-- GetMeleeDamageRangeText
+-- DragonAbility
+mem.asmpatch(0x48CC26, [[
+and eax, ]] .. MaxSkillValStr .. [[;
+lea edi, [eax+0xA]
+]])
+
+-- GetRangedDamageRangeText
+-- DragonAbility
+mem.asmpatch(0x48CCC3, [[
+and eax, ]] .. MaxSkillValStr .. [[;
+lea edi, [eax+0xA]
+]])
+
+-- GetAttackDelay
+-- Sword/Axe/Bow
+asmpatch(0x48D8B6, [[
+mov ecx, esi
+mov edx, ebx
+push eax
+call absolute ]] .. get_player_skill_mastery .. [[;
+cmp eax, 2
+pop eax]], 0x48D8C8 - 0x48D8B6)
+asmpatch(0x48D8CA, [[
+and eax, ]] .. MaxSkillValStr, 0x48D8D1 - 0x48D8CA)
+
+-- Armsmaster
+asmpatch(0x48D8FC, [[
+and edi, ]] .. MaxSkillValStr, 0x48D901 - 0x48D8FC)
+asmpatch(0x48D904, [[
+mov ecx, esi
+mov edx, 0x23
+call absolute ]] .. get_player_skill_mastery)
+
+-- GetResistance
+-- Leather
+mem.asmpatch(0x48DDB9, [[
+mov ax, [esi+0x38A]
+and eax, ]] .. MaxSkillValStr)
+mem.nop(0x48DDBE, 4)
+
+-- CalcStatBonusByItems
+-- DragonAbility
+mem.asmpatch(0x48E2FD, [[
+mov ecx, edi
+and ebx, ]] .. MaxSkillValStr)
+-- Mind Magic
+mem.asmpatch(0x48E75C, [[
+mov ax, [edi+0x39A]
+]])
+-- Magic
+mem.asmpatch(0x48E762, [[
+and eax, ]] .. MaxSkillValStr .. [[;
+shr eax, 1
+]])
+-- Body Magic
+mem.asmpatch(0x48E9D2, [[
+mov ax, [edi+0x39C]
+]])
+-- Air Magic
+mem.asmpatch(0x48E9E8, [[
+mov ax, [edi+0x392]
+]])
+-- Dark Magic
+mem.asmpatch(0x48EA0F, [[
+mov ax, [edi+0x3A0]
+]])
+-- Light Magic
+mem.asmpatch(0x48EA34, [[
+mov ax, [edi+0x39E]
+]])
+-- Fire Magic
+mem.asmpatch(0x48EA4A, [[
+mov ax, [edi+0x390]
+]])
+-- Earth Magic
+mem.asmpatch(0x48EA60, [[
+mov ax, [edi+0x396]
+]])
+-- Water Magic
+mem.asmpatch(0x48EAC9, [[
+mov ax, [edi+0x394]
+]])
+-- Spirit Magic
+mem.asmpatch(0x48EADF, [[
+mov ax, [edi+0x398]
+]])
+
+-- CalcStatBonusBySkills
+-- Armsmaster
+asmpatch(0x48F0AC, [[
+mov ecx, esi
+mov edx, 0x23
+call absolute ]] .. get_player_skill_mastery)
+mem.asmpatch(0x48F0DD, [[
+and edi, ]] .. MaxSkillValStr .. [[;
+imul edi, [ebp-0x4]
+]])
+-- Blaster Shoot / Unarmed
+mem.asmpatch(0x48F1B6, [[
+mov eax, edi
+and eax, ]] .. MaxSkillValStr)
+-- Bow Shoot
+mem.asmpatch(0x48F1C3, [[
+mov eax, [ebp+0x8]
+and eax, ]] .. MaxSkillValStr)
+
+-- Staff/Dagger/Axe/Spear/Mace Damage
+mem.asmpatch(0x48F28E, [[
+mov eax, esi
+and eax, ]] .. MaxSkillValStr)
+
+-- Unarmed Attack
+mem.asmpatch(0x48F2CC, [[
+mov eax, esi
+and eax, ]] .. MaxSkillValStr)
+
+-- Blaster Attack
+mem.asmpatch(0x48F384, [[
+mov eax, esi
+and eax, ]] .. MaxSkillValStr)
+-- Staff Unarmed Attack
+mem.asmpatch(0x48F3C4, [[
+and esi, ]] .. MaxSkillValStr .. [[;
+imul esi, ebx
+]])
+
+-- Staff/Dagger/Axe/Spear/Mace Attack
+mem.asmpatch(0x48F3CD, [[
+mov     eax, [ebp+0x8]
+and     eax, ]] .. MaxSkillValStr)
+-- Armor Class
+mem.asmpatch(0x48F4A4, [[
+and edi, ]] .. MaxSkillValStr .. [[;
+xor ecx, ecx
+]])
+
+-- Dodging Armor Class
+mem.asmpatch(0x48F4F8, [[
+and esi, ]] .. MaxSkillValStr .. [[;
+xor ecx, ecx
+]])
+
+--
+mem.asmpatch(0x49019C, [[
+test ch, 0x10
+jz absolute 0x4901A5
+]])
+mem.asmpatch(0x4901A5, [[
+test ch, 0x8
+jz absolute 0x4901AD
+push 3
+]])
+mem.asmpatch(0x4901AF, [[
+test ch, 0x4
+pop eax
+setnz al
+]])
+
+-- Bodybuilding
+mem.asmpatch(0x4901C6, [[
+and  ecx, ]] .. MaxSkillValStr .. [[;
+imul eax, ecx
+]])
+
+-- Meditation
+mem.asmpatch(0x4901DB, [[
+and  ecx, ]] .. MaxSkillValStr .. [[;
+imul eax, ecx
+]])
+
+-- Id Item
+mem.asmpatch(0x490208, [[
+mov eax, ecx
+and eax, ]] .. MaxSkillValStr)
+
+-- Repair
+mem.asmpatch(0x490255, [[
+mov eax, ecx
+and eax, ]] .. MaxSkillValStr)
+
+-- Merchant
+mem.asmpatch(0x4902A3, [[
+mov ecx, eax
+and esi, ]] .. MaxSkillValStr)
+mem.asmpatch(0x4902D0, [[
+and edi, ]] .. MaxSkillValStr .. [[;
+imul eax, edi
+]])
+
+-- Perception
+mem.asmpatch(0x49030E, [[
+and esi, ]] .. MaxSkillValStr .. [[;
+imul eax, esi
+and edi, ]] .. MaxSkillValStr)
+mem.nop(0x490314, 3)
+
+-- Disarm Traps
+mem.asmpatch(0x490336, [[
+and esi, ]] .. MaxSkillValStr .. [[;
+and edi, ]] .. MaxSkillValStr)
+
+-- Learning
+asmpatch(0x490378, [[
+mov edx, eax
+test edx, edx
+jz @end
+mov ecx, eax
+call absolute 0x49019C
+dec eax
+movzx ecx, word ptr [esi+0x3C4]
+and ecx, ]] .. MaxSkillValStr .. [[;
+imul eax, ecx
+and edx, ]] .. MaxSkillValStr ..[[;
+lea eax, [eax+edx+9]
+@end:
+pop esi
+]], 0x49039A - 0x490378)
+
+-- roster.txt
+mem.asmpatch(0x494C3B, [[
+mov edi, ]] .. GrandMasterBitVStr)
+mem.asmpatch(0x494C5B, [[
+mov edi, ]] .. MasterBitVStr)
+mem.asmpatch(0x494C79, [[
+jnz absolute 0x494C7E
+mov edi, ]] .. ExpertBitVStr)
+
+--[=[
+mem.asmpatch(0x4B0AA5, [[
+lea ecx, [eax+ecx*2+0x378]
+and word ptr [ecx], ]] .. MaxSkillValStr)
+mem.nop(0x4B0AAC, 4)
+]=]
+
+--
+mem.asmpatch(0x4B0E79, [[
+and edi, ]] .. MaxSkillValStr .. [[;
+cmp eax, edx
+]])
+
+-- Donation spell skill value (overwritten in Reputation.lua)
+mem.asmpatch(0x4B5B9E, "or edx, " .. MasterBitVStr)
+
+-- Lloyd's Beacon interface
+--   Patched in SpellsExtra
+--[==[
+mem.asmpatch(0x4D1485, [[
+test ah, 0x10
+mov dword ptr [ebp-0x14], 1
+jnz absolute 0x4D14A2
+test ah, 0x8
+jnz absolute 0x4D14A2
+test ah, 0x4
+]])
+mem.nop2(0x4D148A, 0x4D1497)
+]==]
+--   Patched in SpellsExtra
+--[==[
+mem.asmpatch(0x4D173D, [[
+test ah, 0x10
+mov dword ptr [ebp-0x18], 1
+jnz absolute 0x4D1756
+test ah, 0x8
+jnz absolute 0x4D1756
+test ah, 0x4
+]])
+mem.nop2(0x4D1747, 0x4D174F)
+]==]
+
+Log(Merge.Log.Info, "Init finished: %s", LogId)


### PR DESCRIPTION
[Increased skill cap to 1023](https://github.com/Malekitsu/Maw-Mod-MMMerge/commit/bd11168e41917cabe6de9a4f9e8b3b79fede4e59)
- Adapted RemoveSkillValueLimits.lua file from latest MMMerge code
- Total skill value (base + bonus) capped at 1023
- Base skill value capped at 500
- Save compatibilty preserved with auto conversion
- Removed unnecessary hacky fix for Pain Reflection duration

[Fixed skill bonuses doubling from items and followers](https://github.com/Malekitsu/Maw-Mod-MMMerge/commit/b37afa7854d3c2dbd5abbff6cb930147a1a307b6)
- This is a modification to a standard MMMerge file
- The latest MMMerge code fixes this bug as well, but disables a larger section which includes the PlayerCastSpell events; this change preserves those events required for MAW rebalancing