### PR TITLE
fix non-luadata changes not persisting

### DIFF
--- a/Scripts/General/MenuExtraSettings.lua
+++ b/Scripts/General/MenuExtraSettings.lua
@@ -259,10 +259,7 @@ function events.GameInitialized2()
 			vars.ChallengeMode=true
 		end
 		if vars.Mode==2 then
-			Party.Gold=5000
-			for i=0,Party.High do
-				Party[i].Experience=Party[i].Experience+10000/Party.Count
-			end
+			vars.DoomPartyNeedInit=true
 		end
 		if vars.Mode==6 then
 			vars.AusterityMode=true
@@ -274,6 +271,18 @@ function events.GameInitialized2()
 			vars.onlineMode=true
 		end
 		]]
+	end
+	function events.BeforeLoadMap(wasInGame)
+		if wasInGame or vars.DoomPartyNeedInit == nil then
+			return
+		end
+		vars.DoomPartyNeedInit = nil
+
+
+		Party.Gold=5000
+		for i=0,Party.High do
+			Party[i].Experience=Party[i].Experience+10000/Party.Count
+		end
 	end
 	function events.Action(t)
 		if t.Action==132 or t.Action==124 then
@@ -327,11 +336,14 @@ function events.GameInitialized2()
 		coroutine.resume(coroutine.create(f), Text)
 	end
 
-	function events.LoadMapScripts(WasInGame)
+	function events.BeforeLoadMap(WasInGame)
 		if not WasInGame then
 			vars.ExtraSettings = vars.ExtraSettings or {}
 			local ExSet = vars.ExtraSettings
 
+			if type(ExSet.Mode) ~= "number" then
+				ExSet.Mode = vars.Mode
+			end
 			ExSet.BolsterAmount = ExSet.BolsterAmount or 100
 			if ExSet.ImprovedPathfinding == nil then
 				ExSet.ImprovedPathfinding = true

--- a/Scripts/General/zzMAW-Skills.lua
+++ b/Scripts/General/zzMAW-Skills.lua
@@ -2214,6 +2214,15 @@ end
 
 --fix cover when starting new Game
 function events.BeforeNewGameAutosave()
+	vars.needToFixCover=true
+end
+
+function events.BeforeLoadMap(wasInGame)
+	if wasInGame or vars.needToFixCover == nil then
+		return
+	end
+	vars.needToFixCover=nil
+
 	for i=0,Party.PlayersArray.High do
 		pl=Party.PlayersArray[i]
 		Skillz.set(pl,50,0)

--- a/Scripts/General/zzMaw-Items.lua
+++ b/Scripts/General/zzMaw-Items.lua
@@ -2053,6 +2053,14 @@ end
 ------------------------------------------------------------------
 function events.BeforeNewGameAutosave()
 	vars.hirelingFix=true
+	vars.needToFixMaxCharges=true
+end
+
+function events.BeforeLoadMap(wasInGame)
+	if wasInGame or vars.needToFixMaxCharges == nil then
+		return
+	end
+	vars.needToFixMaxCharges=nil
 	for i=0,Party.High do
 		for j=1, Party[0].Items.High do
 			Party[i].Items[j].MaxCharges=0

--- a/Scripts/Structs/00Skillz.lua
+++ b/Scripts/Structs/00Skillz.lua
@@ -72,22 +72,27 @@ Skillz = {
 
 local thanked = false
 function events.BeforeNewGameAutosave()
-	if (not vars.Skillz_Thanked) then 
-		refund = 0
-		for _, pl in Party do
-			refund = refund + Skillz.CleanMastery(pl)
-		end
-		refund = refund * 500
-		if refund>0 then
-			Party.AddGold(refund)
-		end
+	vars.needToThankSkillz = true
+end
+function events.BeforeLoadMap(wasInGame)
+	if wasInGame or vars.needToThankSkillz == nil then
+		return
+	end
+	vars.needToThankSkillz = nil
+
+	local refund = 0
+	for _, pl in Party do
+		refund = refund + Skillz.CleanMastery(pl)
+	end
+	refund = refund * 500
+	if refund>0 then
+		Party.AddGold(refund)
 	end
 
-    if (not vars.Skillz_Thanked) and (not thanked) then 
+    if not thanked then 
         --Skillz.thanks()
         thanked = true
     end
-    vars.Skillz_Thanked = true
 end
 
 


### PR DESCRIPTION
It seems that all save game data that isn't part of vars is saved before BeforeNewGameAutosave and BeforeSaveGame are run. To work around this, in each case I added a just set a flag indicating that something needs to be initialized and delay initializing until BeforeLoadMap (and clear the flag).