### PR TITLE
make strafing and backwards movement faster while running

### DIFF
--- a/Scripts/General/zMaw-hooks.lua
+++ b/Scripts/General/zMaw-hooks.lua
@@ -1,27 +1,90 @@
-local u1, u2, u4, i1, i2, i4 = mem.u1, mem.u2, mem.u4, mem.i1, mem.i2, mem.i4
-local hook, autohook, autohook2, asmpatch = mem.hook, mem.autohook, mem.autohook2, mem.asmpatch
-local max, min, round, random = math.max, math.min, math.round, math.random
-local format = string.format
 
-local function getSFTItem(p)
-	local i = (p - Game.SFTBin.Frames["?ptr"]) / Game.SFTBin.Frames[0]["?size"]
-	return Game.SFTBin.Frames[i]
-end
-
--- cosmetic change: some monsters (mainly bosses) can be larger
-local scaleHook = function(indoor)
-	return function(d)
-		local t = {Scale = d.eax, Frame = getSFTItem(d.ebx)}
-		t.MonsterIndex, t.Monster = internal.GetMonster(indoor and d.edi or (d.edi - 0x9A))
-		events.call("MonsterSpriteScale", t)
-		d.eax = t.Scale
+do
+	local function getSFTItem(p)
+		local i = (p - Game.SFTBin.Frames["?ptr"]) / Game.SFTBin.Frames[0]["?size"]
+		return Game.SFTBin.Frames[i]
 	end
+
+	-- cosmetic change: some monsters (mainly bosses) can be larger
+	local scaleHook = function(indoor)
+		return function(d)
+			local t = {Scale = d.eax, Frame = getSFTItem(d.ebx)}
+			t.MonsterIndex, t.Monster = internal.GetMonster(indoor and d.edi or (d.edi - 0x9A))
+			events.call("MonsterSpriteScale", t)
+			d.eax = t.Scale
+		end
+	end
+
+	-- outdoor
+	mem.autohook2(0x47AC26, scaleHook())
+	mem.autohook2(0x47AC46, scaleHook())
+
+	-- indoor
+	mem.autohook2(0x43D02E, scaleHook(true))
+	mem.autohook2(0x43D04D, scaleHook(true))
 end
 
--- outdoor
-autohook2(0x47AC26, scaleHook())
-autohook2(0x47AC46, scaleHook())
 
--- indoor
-autohook2(0x43D02E, scaleHook(true))
-autohook2(0x43D04D, scaleHook(true))
+-- make strafe speed always half of forward speed
+--   currently strafe speed is always half of forward walking speed
+--   this doubles running strafe speed
+--   this quadruples flying running strafe speed
+do
+	local function patch(p, code)
+		-- workaround for the fact that asmpatch doesn't currently handle
+		-- the case when GetInstructionSize(p) < GetHookSize(p) correctly
+		mem.nop(p)
+		mem.asmhook(p, code)
+	end
+
+	local code = [[
+		test byte ptr [0xb21730], 0x2
+		jnz @f
+		sar eax, 0x1
+	@@:
+	]]
+
+	patch(0x471a15, code)
+	patch(0x471a45, code)
+	patch(0x471a84, code)
+	patch(0x471ab4, code)
+
+	code = [[
+		test byte ptr [0xb21730], 0x2
+		jnz @running
+		sar eax, 0x1
+		jmp @f
+	@running:
+		cmp dword ptr [0xb215a4], 0x0
+		jz @f
+		shl eax, 0x1
+	@@:
+	]]
+
+	patch(0x472cea, code)
+	patch(0x472d18, code)
+	patch(0x472d59, code)
+	patch(0x472d87, code)
+end
+
+-- make moving backwards always the same speed as moving forwards
+--   this was aready the case when walking and flying, so this only adjusts running while on the ground
+do
+	local code = [[
+		shl eax, 0x1
+	]]
+	mem.asmhook(0x471c2f, code)
+	mem.asmhook(0x471c64, code)
+
+	code = [[
+        cmp dword ptr [ebp - 0x38], 0x0
+		jz @shift
+		cmp dword ptr [ebp - 0x60], 0x0
+		jz @f
+	@shift:
+		shl eax, 0x1
+	@@:
+	]]
+	mem.asmhook(0x473044, code)
+	mem.asmhook(0x473078, code)
+end


### PR DESCRIPTION
this makes strafing speed always equal to half forward movement and backwards speed always the same as forward movement

@Malekitsu I can probably lock this behind an option in zz_Maw-initialize if you'd like